### PR TITLE
update FireTracker adapter to new URL path; bump version to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.1
+* Updated Fire Tracker adapter to adopt new URL scheme.
+
 ## 2.0.0
 #### Additions
 * Added `Adapter#service`, which reads from the `data-service` attribute.

--- a/app/assets/javascripts/embeditor/adapters/fire_tracker.js.coffee
+++ b/app/assets/javascripts/embeditor/adapters/fire_tracker.js.coffee
@@ -1,7 +1,7 @@
 class Embeditor.Adapters.FireTracker extends Embeditor.Adapters.Oembed
     className: "FireTracker"
 
-    @Endpoint = "http://projects.scpr.org/firetracker/oembed"
+    @Endpoint = "http://firetracker.scpr.org/oembed"
 
     @QueryDefaults =
         maxwidth    : 510

--- a/lib/embeditor-rails/version.rb
+++ b/lib/embeditor-rails/version.rb
@@ -1,5 +1,5 @@
 module Embeditor
   module Rails
-    VERSION = "2.0.0"
+    VERSION = "2.0.1"
   end
 end


### PR DESCRIPTION
Hey Bryan,

The newsroom reported that Fire Tracker embed placeholders are not getting replaced with the embed on SCPR.org. I went ahead and updated the endpoint here but wanted to do a PR so you can look all this over before we merge it in and update SCPRv4 to use the latest version of the engine.  
