### PR TITLE
Do not allow null parameters to be passed to oembed endpoints

### DIFF
--- a/app/assets/javascripts/embeditor/adapter.js.coffee
+++ b/app/assets/javascripts/embeditor/adapter.js.coffee
@@ -95,6 +95,6 @@ class Embeditor.Adapter
             continue if !source
 
             for prop,value of source
-                obj[prop] = source[prop] if !obj[prop]
+                obj[prop] = source[prop] if !obj[prop] and value
 
         obj


### PR DESCRIPTION
Embedly seems to now have a problem with null values in the parameters we send, so we will no longer send them.